### PR TITLE
Exclude nginx

### DIFF
--- a/tasks/level-1/1.8.yml
+++ b/tasks/level-1/1.8.yml
@@ -7,6 +7,8 @@
   yum:
     name: "*"
     state: latest
+    exclude:
+      - nginx*
   tags:
     - level-1
     - "1.8"

--- a/tasks/level-1/1.8.yml
+++ b/tasks/level-1/1.8.yml
@@ -7,8 +7,7 @@
   yum:
     name: "*"
     state: latest
-    exclude:
-      - nginx*
+    exclude: nginx*
   tags:
     - level-1
     - "1.8"


### PR DESCRIPTION
/domain @Betterment/squad-sre 
/no-platform

This excludes nginx from being updated when applying the CIS benchmarks. We want to do a phased rollout of updating nginx so that we can update our signal sciences installation along with it.  