### PR TITLE
Clear cache when running upgrade

### DIFF
--- a/tasks/level-1/1.8.yml
+++ b/tasks/level-1/1.8.yml
@@ -8,6 +8,7 @@
     name: "*"
     state: latest
     exclude: nginx*
+    update_cache: true
   tags:
     - level-1
     - "1.8"


### PR DESCRIPTION
/domain @Betterment/squad-sre 
/no-platform
cc @ansongomes 

**What problem does this PR solve / How does it solve it?**
We're seeing failures with this role where it is unable to download OpenResty on many of our machines. After ssh-ing onto a machine and running the commands that Ansible generates, we tracked the problem down to a stale yum cache. This PR adds the `update_cache` attribute to the CIS benchmark task, which _should_ be equivalent to running `yum clean all` before attempting `yum upgrade --exclude=nginx*`.

**Testing done**
Verified the generated yum commands by ssh-ing onto a failed stage box, attempting the run the old commands, seeing the failure, and rerunning with the cleared cache. It worked the second time. 

Also ran this test playbook against a stage box that had failed, referencing the editing role: 

```test.yml
---
- name: Test CIS benchmark
  hosts: all
  roles:
    - { role: "ansible-role-cis-amazon-linux", cis_level_1_exclusions: ["1.1.19", "3.4.2", "3.4.3"]  }
```
