### PR TITLE
Exclude updating java

### DIFF
--- a/tasks/level-1/1.8.yml
+++ b/tasks/level-1/1.8.yml
@@ -7,7 +7,7 @@
   yum:
     name: "*"
     state: latest
-    exclude: nginx*
+    exclude: nginx*,java*
     update_cache: true
   tags:
     - level-1


### PR DESCRIPTION
/domain @squad-sre @ansongomes 
/platform @samandmoore 

Instead of inspecting which patch CIS installs for java, we're just not going to rely on a version that isn't specifically defined by us. This excludes `java*` because we install two java packages:
```
- java-1.7.0-openjdk-devel    
- java-1.8.0-openjdk-devel
```